### PR TITLE
New oauth and also using binary instead of compiling

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,0 +1,3 @@
+oauth2-proxy/oauth2-proxy-v7.12.0.linux-amd64.tar.gz:
+  size: 18660203
+  sha: sha256:e8238d882c549c9341d63ad037bdd476fbd1a40b47f3456ef73db7970b3330dc

--- a/packages/oauth2-proxy/packaging
+++ b/packages/oauth2-proxy/packaging
@@ -1,23 +1,7 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-mkdir -p ${BOSH_INSTALL_TARGET}/src
-mkdir -p ${BOSH_INSTALL_TARGET}/bin
-cp -a . ${BOSH_INSTALL_TARGET}/src
+mkdir oauth2-proxy
+tar zxvf oauth2-proxy/oauth2-proxy-v*.linux-amd64.tar.gz -c oauth2-proxy
 
-source /var/vcap/packages/golang-1.18-linux/bosh/compile.env
-export GOPATH=$BOSH_INSTALL_TARGET
-
-export PATH=$PATH:$(pwd)
-export INSTALL_DIRECTORY=$(pwd)
-
-apt-get update
-apt-get install -y git
-
-pushd ${BOSH_INSTALL_TARGET}/src/github.com/oauth2-proxy/oauth2-proxy
-  go build -buildvcs=false
-  cp oauth2-proxy ${BOSH_INSTALL_TARGET}/bin
-popd
-
-# Clean up source artifacts
-rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg
+cp oauth2-proxy/oauth2-proxy ${BOSH_INSTALL_TARGET}/bin

--- a/packages/oauth2-proxy/spec
+++ b/packages/oauth2-proxy/spec
@@ -1,6 +1,4 @@
 ---
 name: oauth2-proxy
-dependencies:
-- golang-1.18-linux
 files:
-- github.com/**/*
+- oauth2-proxy/oauth2-proxy-v*.linux-amd64.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switching to new oauth2 binary
- binaries are compiled with newer golang
- Make it wayyy easier to update
## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

More fixes is good!