### PR TITLE
Bosh regex is fun

### DIFF
--- a/packages/oauth2-proxy/packaging
+++ b/packages/oauth2-proxy/packaging
@@ -2,6 +2,6 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 mkdir oauth2-proxy
-tar zxvf oauth2-proxy/oauth2-proxy-v*.linux-amd64.tar.gz -c oauth2-proxy
+tar zxvf oauth2-proxy/oauth2-proxy-*.linux-amd64.tar.gz -c oauth2-proxy
 
 cp oauth2-proxy/oauth2-proxy ${BOSH_INSTALL_TARGET}/bin

--- a/packages/oauth2-proxy/spec
+++ b/packages/oauth2-proxy/spec
@@ -1,4 +1,5 @@
 ---
 name: oauth2-proxy
+dependencies:
 files:
-- oauth2-proxy/oauth2-proxy-v*.linux-amd64.tar.gz
+- oauth2-proxy/oauth2-proxy-*.linux-amd64.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:
- Extra V might be the issue
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None