### PR TITLE
missing object id

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 oauth2-proxy/oauth2-proxy-v7.12.0.linux-amd64.tar.gz:
   size: 18660203
+  object_id: 26a7e474-53c6-43a7-5722-db6d7eaf802c
   sha: sha256:e8238d882c549c9341d63ad037bdd476fbd1a40b47f3456ef73db7970b3330dc

--- a/packages/oauth2-proxy/spec
+++ b/packages/oauth2-proxy/spec
@@ -1,4 +1,4 @@
 ---
 name: oauth2-proxy
 files:
-- oauth2-proxy/oauth2-proxy-v7.12.0.linux-amd64.tar.gz
+- oauth2-proxy/oauth2-proxy-*.linux-amd64.tar.gz


### PR DESCRIPTION
## Changes proposed in this pull request:

- object id from bosh upload-blob was missing
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
